### PR TITLE
bugfix: tiles sinking does not mark intended number of tiles

### DIFF
--- a/scripts/utils.gd
+++ b/scripts/utils.gd
@@ -45,11 +45,11 @@ func pick_random_tile(tiles_dict):
 	var keys = tiles_dict.keys()
 	return tiles_dict[keys[randi() % keys.size()]]
 
-func pick_tile_to_sink(tiles: Array):
+func pick_tile_to_sink(tiles: Array, offset: int = 0):
 	if tiles.size() == 1:
 		return tiles[0]
 	tiles.sort_custom(func(a,b): return distance_from_center(a) > distance_from_center(b))
-	return tiles[0]
+	return tiles[min(tiles.size() - 1, 0 + offset)]
 
 func distance_from_center(coords):
 	return abs(coords.x - Constants.WORLD_CENTER.x) + \

--- a/world/world.gd
+++ b/world/world.gd
@@ -264,7 +264,7 @@ func mark_tiles(global_turn):
 	for i in range(tiles_to_mark):
 		var neighbors = self.get_surrounding_cells(cur_cell).filter(func(x): return self.tiles.has(x) and not self.tiles[x].marked)
 		if Utils.rng.randi() % 5 == 0 or neighbors.size() < 1:
-			cur_cell = Utils.pick_tile_to_sink(self.tiles.keys())
+			cur_cell = Utils.pick_tile_to_sink(self.tiles.keys(), i)
 		else:
 			cur_cell = neighbors[randi() % neighbors.size()]
 		self.tiles[cur_cell].mark()


### PR DESCRIPTION
since the tiles are marked only and the pick is now always taking the further tile from the center, we need to have an offset to keep marking new tiles until the target is reached.
The same tile was used as a starting point over and over again.